### PR TITLE
#32 multibuild for usual versions

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,16 +17,22 @@ import sbt._
 
 object Dependencies {
 
-  def sparkVersion: String = sys.props.getOrElse("SPARK_VERSION", "2.4.7")
+  object Versions {
+    val spark2 = "2.4.8"
+    val spark3 = "3.2.3"
 
-  lazy val sparkCore = "org.apache.spark"    %% "spark-core"         % sparkVersion  % "provided"
-  lazy val sparkSql  = "org.apache.spark"    %% "spark-sql"          % sparkVersion  % "provided"
-  lazy val sparkCommon="za.co.absa"          %% "spark-commons-test" % "0.2.0"  % Test
-  lazy val scalaTest = "org.scalatest"       %% "scalatest"          % "3.2.9"  % Test
+    val sparkCommonsTest = "0.2.0"
+    val scalaTest = "3.2.9"
+  }
 
-  lazy val dependencies: Seq[ModuleID] = Seq(
-    sparkCore,
-    sparkSql,
+  def sparkCore(sparkVersion: String) = "org.apache.spark"  %% "spark-core"         % sparkVersion  % Provided
+  def sparkSql(sparkVersion: String)  = "org.apache.spark"  %% "spark-sql"          % sparkVersion  % Provided
+  lazy val sparkCommon                = "za.co.absa"        %% "spark-commons-test" % Versions.sparkCommonsTest % Test
+  lazy val scalaTest                  = "org.scalatest"     %% "scalatest"          % Versions.scalaTest % Test
+
+  def dependencies(sparkVersion: String): Seq[ModuleID] = Seq(
+    sparkCore(sparkVersion),
+    sparkSql(sparkVersion),
     sparkCommon,
     scalaTest
   )


### PR DESCRIPTION
Attempting to solve #32 (and #28).

Building is setup so that:
1 whatever env var `SPARK_VERSION` contains, that will be always used (same as before)
2 if `SPARK_VERSION is not found, Scala 2.11 links Spark 2.4, Scala 2.12 links Spark 3.2


**I am not sure about the release process compatibility with this setup, though**. @Zejnilovic 

## Test-run:
```sbt
> sbt ++2.11.12 package
...
[info] Building with Scala 2.11.12, Spark 2.4.8
```

```sbt
> sbt ++2.12.15 package
...
[info] Building with Scala 2.12.15, Spark 3.2.3
```

```sbt
> sbt ++2.11.12 publishM2
...
[info] Building with Scala 2.11.12, Spark 2.4.8
...
file:/C:/Users/myuser/.m2/repository/za/co/absa/spark-partition-sizing_2.11/0.2.0-SNAPSHOT/spark-partition-sizing_2.11-0.2.0-SNAPSHOT.pom
```
```sbt
> sbt ++2.12.15 publishM2
...
[info] Building with Scala 2.12.15, Spark 3.2.3
...
file:/C:/Users/myuser/.m2/repository/za/co/absa/spark-partition-sizing_2.12/0.2.0-SNAPSHOT/spark-partition-sizing_2.12-0.2.0-SNAPSHOT.pom
...
```

Closes #32
Closes #28